### PR TITLE
Blib math library

### DIFF
--- a/blib.cpp
+++ b/blib.cpp
@@ -98,5 +98,9 @@ int main()
     blib::vec3 cross0 = blib::cross(vec0, vec1);
     blib::vec3 cross1 = blib::cross(norm0, norm1);
 
+    blib::mat4 identity = blib::mat4();
+    blib::mat4 perspectiveOpenGL = blib::perspective(blib::radians(60.0f), 1.0f, 0.1f, 1000.0f);
+    blib::mat4 perspectiveDirectX = blib::perspectiveLH_ZO(blib::radians(60.0f), 1.0f, 0.1f, 1000.0f);
+
     std::cin.get();
 }

--- a/blib.cpp
+++ b/blib.cpp
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include "blib_ec.h"
+#include "blib_math.h"
 
 class transform : public blib::component
 {
@@ -77,4 +78,14 @@ int main()
     auto* not_here_entity_ptr = ec.try_get(e_id);
     if (t_again_ptr)
         std::cout << "not_here_entity_ptr.valid = " << not_here_entity_ptr->valid() << std::endl;
+
+    blib::vec3<float> vec1(0.0, 1.0f, 0.0f);
+    blib::vec3<float> vec2(1.0f, 0.0f, 0.0f);
+    blib::vec3<float> crossRes = blib::cross(vec1, vec2);
+    blib::vec3<float> normRes = blib::normalize(crossRes);
+
+    blib::vec3<float> unnormVec(10.0f, 50.0f, 150.0f);
+    float unnormLength = blib::length(unnormVec);
+    blib::vec3<float> normRes2 = blib::normalize(unnormVec);
+    float length = blib::length(normRes2);
 }

--- a/blib.cpp
+++ b/blib.cpp
@@ -79,13 +79,24 @@ int main()
     if (t_again_ptr)
         std::cout << "not_here_entity_ptr.valid = " << not_here_entity_ptr->valid() << std::endl;
 
-    blib::vec3<float> vec1(0.0, 1.0f, 0.0f);
-    blib::vec3<float> vec2(1.0f, 0.0f, 0.0f);
-    blib::vec3<float> crossRes = blib::cross(vec1, vec2);
-    blib::vec3<float> normRes = blib::normalize(crossRes);
+    // Dot product
+    blib::vec3 vec0(15.0f, 89.4961230f, 0.7129837f);
+    blib::vec3 vec1(-7.81234f, 0.12f, 19.879f);
+    float dot0 = blib::dot(vec0, vec1);
 
-    blib::vec3<float> unnormVec(10.0f, 50.0f, 150.0f);
-    float unnormLength = blib::length(unnormVec);
-    blib::vec3<float> normRes2 = blib::normalize(unnormVec);
-    float length = blib::length(normRes2);
+    // Length
+    float length0 = blib::length(vec0);
+    float length1 = blib::length(vec1);
+
+    // Normalize
+    blib::vec3 norm0 = blib::normalize(vec0);
+    blib::vec3 norm1 = blib::normalize(vec1);
+
+    // Cross product
+    vec0 = blib::vec3(0.0f, 1.0f, 0.0f);
+    vec1 = blib::vec3(1.0f, 0.0f, 0.0f);
+    blib::vec3 cross0 = blib::cross(vec0, vec1);
+    blib::vec3 cross1 = blib::cross(norm0, norm1);
+
+    std::cin.get();
 }

--- a/blib.vcxproj
+++ b/blib.vcxproj
@@ -137,6 +137,7 @@
   <ItemGroup>
     <ClInclude Include="blib_ec.h" />
     <ClInclude Include="blib_fileio.h" />
+    <ClInclude Include="blib_math.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/blib.vcxproj.filters
+++ b/blib.vcxproj.filters
@@ -26,5 +26,8 @@
     <ClInclude Include="blib_fileio.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="blib_math.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/blib_math.h
+++ b/blib_math.h
@@ -1,10 +1,17 @@
 #pragma once
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include <type_traits>
 
 /*
 
-	Todo: Quat, translate, rotate, scale, using typename aliases, eliminate bracket operator code duplication
-
+	---------------------------------------------------------------------------------
+											Todo
+	Quat, translate, rotate, scale
+	Ortho, view (lookAt), Unit testing
+	
+	---------------------------------------------------------------------------------
+											Done
 	Vec2: Constructors / arithmetic operators / bracket operators
 	Vec3: Constructors / arithmetic operators / bracket operators
 	Vec4: Constructors / arithmetic operators / bracket operators
@@ -12,7 +19,11 @@
 	Mat4: Constructors / arithmetic operators / bracket operators
 	Quat: -
 
-	Func: Dot product / Cross product / Length / Normalize
+	Vector func: Dot product / Cross product / Length / Normalize
+	Matrix func: Transpose / Perspective left-handed and right-handed, 0..1 and -1..1
+	Func: Radians / Degrees
+	Default types for float/double/uint/int vectors and matrices
+	---------------------------------------------------------------------------------
 
 */
 namespace blib
@@ -22,7 +33,7 @@ namespace blib
 	vec2 implementation
 */
 template<typename T>
-struct default_vec2
+struct vec2_t
 {
 	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
@@ -31,12 +42,12 @@ struct default_vec2
 	/*
 		Constructors
 	*/
-	default_vec2() = default;
-	default_vec2(T scalar)
+	vec2_t() = default;
+	vec2_t(T scalar)
 	{
 		x = y = scalar;
 	}
-	default_vec2(T _x, T _y)
+	vec2_t(T _x, T _y)
 	{
 		x = _x;
 		y = _y;
@@ -45,44 +56,44 @@ struct default_vec2
 	/*
 		Arithmetic operators
 	*/
-	constexpr default_vec2 operator+(const default_vec2& other)
+	constexpr vec2_t operator+(const vec2_t& other)
 	{
 		return { x + other.x, y + other.y };
 	}
-	constexpr default_vec2& operator+=(const default_vec2& other)
+	constexpr vec2_t& operator+=(const vec2_t& other)
 	{
 		x += other.x;
 		y += other.y;
 		return *this;
 	}
 
-	constexpr default_vec2 operator-(const default_vec2& other)
+	constexpr vec2_t operator-(const vec2_t& other)
 	{
 		return { x - other.x, y - other.y };
 	}
-	constexpr default_vec2& operator-=(const default_vec2& other)
+	constexpr vec2_t& operator-=(const vec2_t& other)
 	{
 		x -= other.x;
 		y -= other.y;
 		return *this;
 	}
 
-	constexpr default_vec2 operator*(const default_vec2& other)
+	constexpr vec2_t operator*(const vec2_t& other)
 	{
 		return { x * other.x, y * other.y };
 	}
-	constexpr default_vec2& operator*=(const default_vec2& other)
+	constexpr vec2_t& operator*=(const vec2_t& other)
 	{
 		x *= other.x;
 		y *= other.y;
 		return *this;
 	}
 
-	constexpr default_vec2 operator/(const default_vec2& other)
+	constexpr vec2_t operator/(const vec2_t& other)
 	{
 		return { x / other.x, y / other.y };
 	}
-	constexpr default_vec2& operator/=(const default_vec2& other)
+	constexpr vec2_t& operator/=(const vec2_t& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -92,19 +103,6 @@ struct default_vec2
 	/*
 		Bracket operators
 	*/
-	T& operator[](uint32_t index)
-	{
-		assert(index >= 0 && index < 2);
-		switch (index)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		}
-	}
-
 	T const& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 2);
@@ -118,18 +116,23 @@ struct default_vec2
 		}
 	}
 
+	T& operator[](uint32_t index)
+	{
+		return const_cast<T&>(static_cast<const vec2_t<T>&>(*this)[index]);
+	}
+
 };
 
 /*
-	Binary arithmetic operators (default_vec2)
+	Binary arithmetic operators (vec2_t)
 */
 template<typename T>
-constexpr default_vec2<T> operator+(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T> operator+(const vec2_t<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar };
 }
 template<typename T>
-constexpr default_vec2<T>& operator+=(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T>& operator+=(const vec2_t<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -137,12 +140,12 @@ constexpr default_vec2<T>& operator+=(const default_vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec2<T> operator-(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T> operator-(const vec2_t<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar };
 }
 template<typename T>
-constexpr default_vec2<T>& operator-=(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T>& operator-=(const vec2_t<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -150,12 +153,12 @@ constexpr default_vec2<T>& operator-=(const default_vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec2<T> operator*(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T> operator*(const vec2_t<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar };
 }
 template<typename T>
-constexpr default_vec2<T>& operator*=(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T>& operator*=(const vec2_t<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -163,12 +166,12 @@ constexpr default_vec2<T>& operator*=(const default_vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec2<T> operator/(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T> operator/(const vec2_t<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar };
 }
 template<typename T>
-constexpr default_vec2<T>& operator/=(const default_vec2<T>& v0, T scalar)
+constexpr vec2_t<T>& operator/=(const vec2_t<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -179,7 +182,7 @@ constexpr default_vec2<T>& operator/=(const default_vec2<T>& v0, T scalar)
 	vec3 implementation
 */
 template<typename T>
-struct default_vec3
+struct vec3_t
 {
 	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
@@ -188,12 +191,12 @@ struct default_vec3
 	/*
 		Constructors
 	*/
-	default_vec3() = default;
-	default_vec3(T scalar)
+	vec3_t() = default;
+	vec3_t(T scalar)
 	{
 		x = y = z = scalar;
 	}
-	default_vec3(T _x, T _y, T _z)
+	vec3_t(T _x, T _y, T _z)
 	{
 		x = _x;
 		y = _y;
@@ -203,11 +206,11 @@ struct default_vec3
 	/*
 		Unary arithmetic operators
 	*/
-	constexpr default_vec3 operator+(const default_vec3& other)
+	constexpr vec3_t operator+(const vec3_t& other)
 	{
 		return { x + other.x, y + other.y, z + other.z };
 	}
-	constexpr default_vec3& operator+=(const default_vec3& other)
+	constexpr vec3_t& operator+=(const vec3_t& other)
 	{
 		x += other.x;
 		y += other.y;
@@ -215,11 +218,11 @@ struct default_vec3
 		return *this;
 	}
 
-	constexpr default_vec3 operator-(const default_vec3& other)
+	constexpr vec3_t operator-(const vec3_t& other)
 	{
 		return { x - other.x, y - other.y, z - other.z };
 	}
-	constexpr default_vec3& operator-=(const default_vec3& other)
+	constexpr vec3_t& operator-=(const vec3_t& other)
 	{
 		x -= other.x;
 		y -= other.y;
@@ -227,11 +230,11 @@ struct default_vec3
 		return *this;
 	}
 
-	constexpr default_vec3 operator*(const default_vec3& other)
+	constexpr vec3_t operator*(const vec3_t& other)
 	{
 		return { x * other.x, y * other.y, z * other.z };
 	}
-	constexpr default_vec3& operator*=(const default_vec3& other)
+	constexpr vec3_t& operator*=(const vec3_t& other)
 	{
 		x *= other.x;
 		y *= other.y;
@@ -239,11 +242,11 @@ struct default_vec3
 		return *this;
 	}
 
-	constexpr default_vec3 operator/(const default_vec3& other)
+	constexpr vec3_t operator/(const vec3_t& other)
 	{
 		return { x / other.x, y / other.y, z / other.z };
 	}
-	constexpr default_vec3& operator/=(const default_vec3& other)
+	constexpr vec3_t& operator/=(const vec3_t& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -254,21 +257,6 @@ struct default_vec3
 	/*
 		Bracket operators
 	*/
-	T& operator[](uint32_t index)
-	{
-		assert(index >= 0 && index < 3);
-		switch (index)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		case 2:
-			return z;
-		}
-	}
-
 	T const& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 3);
@@ -284,18 +272,23 @@ struct default_vec3
 		}
 	}
 
+	T& operator[](uint32_t index)
+	{
+		return const_cast<T&>(static_cast<const vec3_t<T>&>(*this)[index]);
+	}
+
 };
 
 /*
-	Binary arithmetic operators (default_vec3)
+	Binary arithmetic operators (vec3_t)
 */
 template<typename T>
-constexpr default_vec3<T> operator+(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T> operator+(const vec3_t<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar, v0.z + scalar };
 }
 template<typename T>
-constexpr default_vec3<T>& operator+=(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T>& operator+=(const vec3_t<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -304,12 +297,12 @@ constexpr default_vec3<T>& operator+=(const default_vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec3<T> operator-(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T> operator-(const vec3_t<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar, v0.z - scalar };
 }
 template<typename T>
-constexpr default_vec3<T>& operator-=(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T>& operator-=(const vec3_t<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -318,12 +311,12 @@ constexpr default_vec3<T>& operator-=(const default_vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec3<T> operator*(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T> operator*(const vec3_t<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar, v0.z * scalar };
 }
 template<typename T>
-constexpr default_vec3<T>& operator*=(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T>& operator*=(const vec3_t<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -332,12 +325,12 @@ constexpr default_vec3<T>& operator*=(const default_vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec3<T> operator/(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T> operator/(const vec3_t<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar, v0.z / scalar };
 }
 template<typename T>
-constexpr default_vec3<T>& operator/=(const default_vec3<T>& v0, T scalar)
+constexpr vec3_t<T>& operator/=(const vec3_t<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -349,7 +342,7 @@ constexpr default_vec3<T>& operator/=(const default_vec3<T>& v0, T scalar)
 	vec4 implementation
 */
 template<typename T>
-struct default_vec4
+struct vec4_t
 {
 	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
@@ -358,12 +351,12 @@ struct default_vec4
 	/*
 		Constructors
 	*/
-	default_vec4() = default;
-	default_vec4(T scalar)
+	vec4_t() = default;
+	vec4_t(T scalar)
 	{
 		x = y = z = w = scalar;
 	}
-	default_vec4(T _x, T _y, T _z, T _w)
+	vec4_t(T _x, T _y, T _z, T _w)
 	{
 		x = _x;
 		y = _y;
@@ -374,11 +367,11 @@ struct default_vec4
 	/*
 		Arithmetic operators
 	*/
-	constexpr default_vec4 operator+(const default_vec4& other)
+	constexpr vec4_t operator+(const vec4_t& other)
 	{
 		return { x + other.x, y + other.y, z + other.z, w + other.w };
 	}
-	constexpr default_vec4& operator+=(const default_vec4& other)
+	constexpr vec4_t& operator+=(const vec4_t& other)
 	{
 		x += other.x;
 		y += other.y;
@@ -387,11 +380,11 @@ struct default_vec4
 		return *this;
 	}
 
-	constexpr default_vec4 operator-(const default_vec4& other)
+	constexpr vec4_t operator-(const vec4_t& other)
 	{
 		return { x - other.x, y - other.y, z - other.z, w - other.w };
 	}
-	constexpr default_vec4& operator-=(const default_vec4& other)
+	constexpr vec4_t& operator-=(const vec4_t& other)
 	{
 		x -= other.x;
 		y -= other.y;
@@ -400,11 +393,11 @@ struct default_vec4
 		return *this;
 	}
 
-	constexpr default_vec4 operator*(const default_vec4& other)
+	constexpr vec4_t operator*(const vec4_t& other)
 	{
 		return { x * other.x, y * other.y, z * other.z, w * other.w };
 	}
-	constexpr default_vec4& operator*=(const default_vec4& other)
+	constexpr vec4_t& operator*=(const vec4_t& other)
 	{
 		x *= other.x;
 		y *= other.y;
@@ -413,11 +406,11 @@ struct default_vec4
 		return *this;
 	}
 
-	constexpr default_vec4 operator/(const default_vec4& other)
+	constexpr vec4_t operator/(const vec4_t& other)
 	{
 		return { x / other.x, y / other.y, z / other.z, w / other.w };
 	}
-	constexpr default_vec4& operator/=(const default_vec4& other)
+	constexpr vec4_t& operator/=(const vec4_t& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -429,23 +422,6 @@ struct default_vec4
 	/*
 		Bracket operators
 	*/
-	T& operator[](uint32_t index)
-	{
-		assert(index >= 0 && index < 4);
-		switch (index)
-		{
-		default:
-		case 0:
-			return x;
-		case 1:
-			return y;
-		case 2:
-			return z;
-		case 3:
-			return w;
-		}
-	}
-
 	T const& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 4);
@@ -463,18 +439,23 @@ struct default_vec4
 		}
 	}
 
+	T& operator[](uint32_t index)
+	{
+		return const_cast<T&>(static_cast<const vec4_t<T>&>(*this)[index]);
+	}
+
 };
 
 /*
-	Binary arithmetic operators (default_vec4)
+	Binary arithmetic operators (vec4_t)
 */
 template<typename T>
-constexpr default_vec4<T> operator+(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T> operator+(const vec4_t<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar, v0.z + scalar, v0.w + scalar };
 }
 template<typename T>
-constexpr default_vec4<T>& operator+=(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T>& operator+=(const vec4_t<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -484,12 +465,12 @@ constexpr default_vec4<T>& operator+=(const default_vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec4<T> operator-(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T> operator-(const vec4_t<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar, v0.z - scalar, v0.w - scalar };
 }
 template<typename T>
-constexpr default_vec4<T>& operator-=(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T>& operator-=(const vec4_t<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -499,12 +480,12 @@ constexpr default_vec4<T>& operator-=(const default_vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec4<T> operator*(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T> operator*(const vec4_t<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar, v0.z * scalar, v0.w * scalar };
 }
 template<typename T>
-constexpr default_vec4<T>& operator*=(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T>& operator*=(const vec4_t<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -514,12 +495,12 @@ constexpr default_vec4<T>& operator*=(const default_vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr default_vec4<T> operator/(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T> operator/(const vec4_t<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar, v0.z / scalar, v0.w / scalar };
 }
 template<typename T>
-constexpr default_vec4<T>& operator/=(const default_vec4<T>& v0, T scalar)
+constexpr vec4_t<T>& operator/=(const vec4_t<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -532,28 +513,28 @@ constexpr default_vec4<T>& operator/=(const default_vec4<T>& v0, T scalar)
 	mat3 implementation
 */
 template<typename T>
-struct default_mat3
+struct mat3_t
 {
 	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
-	default_vec3<T> value[3];
+	vec3_t<T> value[3];
 
 	/*
 		Constructors
 	*/
-	default_mat3()
+	mat3_t()
 	{
 		value[0] = { 1, 0, 0 };
 		value[0] = { 0, 1, 0 };
 		value[0] = { 0, 0, 1 };
 	}
-	default_mat3(T scalar)
+	mat3_t(T scalar)
 	{
 		value[0] = scalar;
 		value[1] = scalar;
 		value[2] = scalar;
 	}
-	default_mat3(const default_vec3<T>& v0, const default_vec3<T>& v1, const default_vec3<T>& v2)
+	mat3_t(const vec3_t<T>& v0, const vec3_t<T>& v1, const vec3_t<T>& v2)
 	{
 		value[0] = v0;
 		value[1] = v1;
@@ -563,11 +544,11 @@ struct default_mat3
 	/*
 		Arithmetic operators
 	*/
-	constexpr default_mat3 operator+(const default_mat3<T>& other)
+	constexpr mat3_t operator+(const mat3_t<T>& other)
 	{
 		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2] };
 	}
-	constexpr default_mat3& operator+=(const default_mat3<T>& other)
+	constexpr mat3_t& operator+=(const mat3_t<T>& other)
 	{
 		value[0] += other.value[0];
 		value[1] += other.value[1];
@@ -575,11 +556,11 @@ struct default_mat3
 		return *this;
 	}
 
-	constexpr default_mat3 operator-(const default_mat3<T>& other)
+	constexpr mat3_t operator-(const mat3_t<T>& other)
 	{
 		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2] };
 	}
-	constexpr default_mat3& operator-=(const default_mat3<T>& other)
+	constexpr mat3_t& operator-=(const mat3_t<T>& other)
 	{
 		value[0] -= other.value[0];
 		value[1] -= other.value[1];
@@ -587,11 +568,11 @@ struct default_mat3
 		return *this;
 	}
 
-	constexpr default_mat3 operator*(const default_mat3<T>& other)
+	constexpr mat3_t operator*(const mat3_t<T>& other)
 	{
 		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2] };
 	}
-	constexpr default_mat3& operator*=(const default_mat3<T>& other)
+	constexpr mat3_t& operator*=(const mat3_t<T>& other)
 	{
 		value[0] *= other.value[0];
 		value[1] *= other.value[1];
@@ -599,11 +580,11 @@ struct default_mat3
 		return *this;
 	}
 
-	constexpr default_mat3 operator/(const default_mat3<T>& other)
+	constexpr mat3_t operator/(const mat3_t<T>& other)
 	{
 		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2] };
 	}
-	constexpr default_mat3& operator/=(const default_mat3<T>& other)
+	constexpr mat3_t& operator/=(const mat3_t<T>& other)
 	{
 		value[0] /= other.value[0];
 		value[1] /= other.value[1];
@@ -614,16 +595,15 @@ struct default_mat3
 	/*
 		Bracket operators
 	*/
-	default_vec3<T>& operator[](uint32_t index)
+	const vec3_t<T>& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 3);
 		return value[index];
 	}
 
-	const default_vec3<T>& operator[](uint32_t index) const
+	vec3_t<T>& operator[](uint32_t index)
 	{
-		assert(index >= 0 && index < 3);
-		return value[index];
+		return const_cast<vec3_t<T>&>(static_cast<const mat3_t<T>&>(*this)[index]);
 	}
 
 };
@@ -632,30 +612,30 @@ struct default_mat3
 	mat4 implementation
 */
 template<typename T>
-struct default_mat4
+struct mat4_t
 {
 	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
-	default_vec4<T> value[4];
+	vec4_t<T> value[4];
 
 	/*
 		Constructors
 	*/
-	default_mat4()
+	mat4_t()
 	{
 		value[0] = { 1, 0, 0, 0 };
 		value[1] = { 0, 1, 0, 0 };
 		value[2] = { 0, 0, 1, 0 };
 		value[3] = { 0, 0, 0, 1 };
 	}
-	default_mat4(T scalar)
+	mat4_t(T scalar)
 	{
 		value[0] = scalar;
 		value[1] = scalar;
 		value[2] = scalar;
 		value[3] = scalar;
 	}
-	default_mat4(const default_vec4<T>& v0, const default_vec4<T>& v1, const default_vec4<T>& v2, const default_vec4<T>& v3)
+	mat4_t(const vec4_t<T>& v0, const vec4_t<T>& v1, const vec4_t<T>& v2, const vec4_t<T>& v3)
 	{
 		value[0] = v0;
 		value[1] = v1;
@@ -666,11 +646,11 @@ struct default_mat4
 	/*
 		Arithmetic operators
 	*/
-	constexpr default_mat4 operator+(const default_mat4<T>& other)
+	constexpr mat4_t operator+(const mat4_t<T>& other)
 	{
 		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2], value[3] + other.value[3] };
 	}
-	constexpr default_mat4& operator+=(const default_mat4<T>& other)
+	constexpr mat4_t& operator+=(const mat4_t<T>& other)
 	{
 		value[0] += other.value[0];
 		value[1] += other.value[1];
@@ -679,11 +659,11 @@ struct default_mat4
 		return *this;
 	}
 
-	constexpr default_mat4 operator-(const default_mat4<T>& other)
+	constexpr mat4_t operator-(const mat4_t<T>& other)
 	{
 		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2], value[3] - other.value[3] };
 	}
-	constexpr default_mat4& operator-=(const default_mat4<T>& other)
+	constexpr mat4_t& operator-=(const mat4_t<T>& other)
 	{
 		value[0] -= other.value[0];
 		value[1] -= other.value[1];
@@ -692,11 +672,11 @@ struct default_mat4
 		return *this;
 	}
 
-	constexpr default_mat4 operator*(const default_mat4<T>& other)
+	constexpr mat4_t operator*(const mat4_t<T>& other)
 	{
 		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2], value[3] * other.value[3] };
 	}
-	constexpr default_mat4& operator*=(const default_mat4<T>& other)
+	constexpr mat4_t& operator*=(const mat4_t<T>& other)
 	{
 		value[0] *= other.value[0];
 		value[1] *= other.value[1];
@@ -705,11 +685,11 @@ struct default_mat4
 		return *this;
 	}
 
-	constexpr default_mat4 operator/(const default_mat4<T>& other)
+	constexpr mat4_t operator/(const mat4_t<T>& other)
 	{
 		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2], value[3] / other.value[3] };
 	}
-	constexpr default_mat4& operator/=(const default_mat4<T>& other)
+	constexpr mat4_t& operator/=(const mat4_t<T>& other)
 	{
 		value[0] /= other.value[0];
 		value[1] /= other.value[1];
@@ -721,40 +701,45 @@ struct default_mat4
 	/*
 		Bracket operators
 	*/
-	default_vec4<T>& operator[](uint32_t index)
+	const vec4_t<T>& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 4);
 		return value[index];
 	}
 
-	const default_vec4<T>& operator[](uint32_t index) const
+	vec4_t<T>& operator[](uint32_t index)
 	{
-		assert(index >= 0 && index < 4);
-		return value[index];
+		return const_cast<vec4_t<T>&>(static_cast<const mat4_t<T>&>(*this)[index]);
 	}
 
 };
 
+/*
+
+	Vector functions
+
+*/
+
 template<typename T>
-inline constexpr T dot(const default_vec2<T>& v0, const default_vec2<T>& v1)
+inline constexpr T dot(const vec2_t<T>& v0, const vec2_t<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y;
 }
 
 template<typename T>
-inline constexpr T dot(const default_vec3<T>& v0, const default_vec3<T>& v1)
+inline constexpr T dot(const vec3_t<T>& v0, const vec3_t<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z;
 }
 
 template<typename T>
-inline constexpr T dot(const default_vec4<T>& v0, const default_vec4<T>& v1)
+inline constexpr T dot(const vec4_t<T>& v0, const vec4_t<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z + v0.w * v1.w;
 }
 
 template<typename T>
-inline constexpr default_vec3<T> cross(const default_vec3<T>& v0, const default_vec3<T>& v1)
+inline constexpr vec3_t<T> cross(const vec3_t<T>& v0, const vec3_t<T>& v1)
 {
 	return {
 		v0.y * v1.z - v0.z * v1.y,
@@ -764,45 +749,268 @@ inline constexpr default_vec3<T> cross(const default_vec3<T>& v0, const default_
 }
 
 template<typename T>
-inline constexpr T length(const default_vec2<T>& v0)
+inline constexpr T length(const vec2_t<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr T length(const default_vec3<T>& v0)
+inline constexpr T length(const vec3_t<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr T length(const default_vec4<T>& v0)
+inline constexpr T length(const vec4_t<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr default_vec2<T> normalize(const default_vec2<T>& v0)
+inline constexpr vec2_t<T> normalize(const vec2_t<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
 
 template<typename T>
-inline constexpr default_vec3<T> normalize(const default_vec3<T>& v0)
+inline constexpr vec3_t<T> normalize(const vec3_t<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
 
 template<typename T>
-inline constexpr default_vec4<T> normalize(const default_vec4<T>& v0)
+inline constexpr vec4_t<T> normalize(const vec4_t<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
 
-using vec2 = default_vec2<float>;
-using vec3 = default_vec3<float>;
-using vec4 = default_vec4<float>;
-using mat3 = default_mat3<float>;
-using mat4 = default_mat4<float>;
+/*
+
+	Additional useful functions
+
+*/
+template<typename T>
+inline constexpr T degrees(T rad)
+{
+	return (180 * rad) / M_PI;
+}
+
+template<typename T>
+inline constexpr T radians(T deg)
+{
+	return (M_PI * deg) / 180;
+}
+
+/*
+
+	Matrix functions
+
+*/
+
+template<typename T>
+inline constexpr mat3_t<T> transpose(const mat3_t<T>& mat3)
+{
+	mat3_t<T> newMat3 = mat3;
+	newMat3[0][1] = mat3[1][0];
+	newMat3[0][2] = mat3[2][0];
+	newMat3[1][0] = mat3[0][1];
+	newMat3[1][2] = mat3[2][1];
+	newMat3[2][0] = mat3[0][2];
+	newMat3[2][1] = mat3[1][2];
+
+	return mat3;
+}
+
+template<typename T>
+inline constexpr mat4_t<T> transpose(const mat4_t<T>& mat4)
+{
+	mat4_t<T> newMat4 = mat4;
+	mat4[0][1] = mat4[1][0];
+	mat4[0][2] = mat4[2][0];
+	mat4[0][3] = mat4[3][0];
+	mat4[1][0] = mat4[0][1];
+	mat4[1][2] = mat4[2][1];
+	mat4[1][3] = mat4[3][1];
+	mat4[2][0] = mat4[0][2];
+	mat4[2][1] = mat4[1][2];
+	mat4[2][3] = mat4[3][2];
+
+	return newMat4;
+}
+
+// Todo: Add translate, rotate, scale here
+
+/*
+
+	Perspective projection matrix functions
+
+*/
+
+// Creates a right-handed perspective projection, with the normalized device z coordinate mapped between 0 and 1
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveRH_ZO(T fov, T aspectRatio, T near, T far)
+{
+	mat4_t<T> mat;
+
+	T g = tan(fov / 2);
+	T k = far / (far - near);
+
+	mat[0][0] = g / aspectRatio;
+	mat[1][1] = g;
+	mat[2][2] = k;
+	mat[2][3] = -near * k;
+	mat[3][2] = 1;
+	mat[3][3] = 0;
+
+	return mat;
+}
+
+// Creates a right-handed perspective projection, with the normalized device z coordinate mapped between 0 and 1
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveRH_ZO(T fov, T width, T height, T near, T far)
+{
+	return perspectiveRH_ZO<T>(fov, width / height, near, far);
+}
+
+// Creates a right-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1 (OpenGL)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveRH_NO(T fov, T aspectRatio, T near, T far)
+{
+	mat4_t<T> mat;
+
+	T g = tan(fov / 2);
+
+	mat[0][0] = g / aspectRatio;
+	mat[1][1] = g;
+	mat[2][2] = (far + near) / (near - far);
+	mat[2][3] = (2 * far * near) / (near - far);
+	mat[3][2] = -1;
+	mat[3][3] = 0;
+
+	return mat;
+}
+
+// Creates a right-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1 (OpenGL)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveRH_NO(T fov, T width, T height, T near, T far)
+{
+	return perspectiveRH_NO<T>(fov, width / height, near, far);
+}
+
+// Creates a left-handed perspective projection, with the normalized device z coordinate mapped between 0 and 1 (DirectX)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveLH_ZO(T fov, T aspectRatio, T near, T far)
+{
+	mat4_t<T> mat;
+
+	T g = tan(fov / 2);
+	T k = far / (far - near);
+
+	mat[0][0] = -g / aspectRatio;
+	mat[1][1] = -g;
+	mat[2][2] = k;
+	mat[2][3] = -near * k;
+	mat[3][2] = 1;
+	mat[3][3] = 0;
+
+	return mat;
+}
+
+// Creates a left-handed perspective projection, with the normalized device z coordinate mapped between 0 and 1 (DirectX)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveLH_ZO(T fov, T width, T height, T near, T far)
+{
+	return perspectiveLH_ZO<T>(fov, width / height, near, far);
+}
+
+// Creates a left-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveLH_NO(T fov, T aspectRatio, T near, T far)
+{
+	mat4_t<T> mat;
+
+	T g = tan(fov / 2);
+
+	mat[0][0] = -g / aspectRatio;
+	mat[1][1] = -g;
+	mat[2][2] = (far + near) / (near - far);
+	mat[2][3] = (2 * far * near) / (near - far);
+	mat[3][2] = -1;
+	mat[3][3] = 0;
+
+	return mat;
+}
+
+// Creates a left-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspectiveLH_NO(T fov, T width, T height, T near, T far)
+{
+	return perspectiveLH_NO<T>(fov, width / height, near, far);
+}
+
+// By default this constructs a right-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1 (OpenGL)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspective(T fov, T aspectRatio, T near, T far)
+{
+	return perspectiveRH_NO<T>(fov, aspectRatio, near, far);
+}
+
+// By default this constructs a right-handed perspective projection, with the normalized device z coordinate mapped between -1 and 1 (OpenGL)
+// FOV must be in radians
+template<typename T>
+constexpr mat4_t<T> perspective(T fov, T width, T height, T near, T far)
+{
+	return perspective<T>(fov, width / height, near, far);
+}
+
+/*
+
+	Orthographic projection matrix functions
+
+*/
+
+
+/*
+
+	View matrix functions
+
+*/
+
+// Float vectors and matrices
+using vec2 = vec2_t<float>;
+using vec3 = vec3_t<float>;
+using vec4 = vec4_t<float>;
+using mat3 = mat3_t<float>;
+using mat4 = mat4_t<float>;
+
+// Double vectors and matrices
+using dvec2 = vec2_t<double>;
+using dvec3 = vec3_t<double>;
+using dvec4 = vec4_t<double>;
+using dmat3 = mat3_t<double>;
+using dmat4 = mat4_t<double>;
+
+// Unsigned integer vectors and matrices
+using uvec2 = vec2_t<unsigned int>;
+using uvec3 = vec3_t<unsigned int>;
+using uvec4 = vec4_t<unsigned int>;
+using umat3 = mat3_t<unsigned int>;
+using umat4 = mat4_t<unsigned int>;
+
+// Integer vectors and matrices
+using ivec2 = vec2_t<int>;
+using ivec3 = vec3_t<int>;
+using ivec4 = vec4_t<int>;
+using imat3 = mat3_t<int>;
+using imat4 = mat4_t<int>;
 
 }

--- a/blib_math.h
+++ b/blib_math.h
@@ -541,7 +541,12 @@ struct default_mat3
 	/*
 		Constructors
 	*/
-	default_mat3() = default;
+	default_mat3()
+	{
+		value[0] = { 1, 0, 0 };
+		value[0] = { 0, 1, 0 };
+		value[0] = { 0, 0, 1 };
+	}
 	default_mat3(T scalar)
 	{
 		value[0] = scalar;
@@ -636,7 +641,13 @@ struct default_mat4
 	/*
 		Constructors
 	*/
-	default_mat4() = default;
+	default_mat4()
+	{
+		value[0] = { 1, 0, 0, 0 };
+		value[1] = { 0, 1, 0, 0 };
+		value[2] = { 0, 0, 1, 0 };
+		value[3] = { 0, 0, 0, 1 };
+	}
 	default_mat4(T scalar)
 	{
 		value[0] = scalar;

--- a/blib_math.h
+++ b/blib_math.h
@@ -1,0 +1,791 @@
+#pragma once
+#include <type_traits>
+
+/*
+
+	Todo: Constructors / arithmetic operators / bracket operators
+
+	Vec2: Constructors / arithmetic operators / bracket operators
+	Vec3: Constructors / arithmetic operators / bracket operators
+	Vec4: Constructors / arithmetic operators / bracket operators
+	Mat3: Constructors / arithmetic operators / bracket operators
+	Mat4: Constructors / arithmetic operators / bracket operators
+	Quat: -
+
+	Func: Dot product / Cross product / Length / Normalize
+
+*/
+namespace blib
+{
+
+/*
+	vec2 implementation
+*/
+template<typename T>
+struct vec2
+{
+	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+
+	T x = 0, y = 0;
+
+	/*
+		Constructors
+	*/
+	vec2() = default;
+	vec2(T scalar)
+	{
+		x = y = scalar;
+	}
+	vec2(T _x, T _y)
+	{
+		x = _x;
+		y = _y;
+	}
+
+	/*
+		Arithmetic operators
+	*/
+	constexpr vec2 operator+(const vec2& other)
+	{
+		return { x + other.x, y + other.y };
+	}
+	constexpr vec2& operator+=(const vec2& other)
+	{
+		x += other.x;
+		y += other.y;
+		return *this;
+	}
+
+	constexpr vec2 operator-(const vec2& other)
+	{
+		return { x - other.x, y - other.y };
+	}
+	constexpr vec2& operator-=(const vec2& other)
+	{
+		x -= other.x;
+		y -= other.y;
+		return *this;
+	}
+
+	constexpr vec2 operator*(const vec2& other)
+	{
+		return { x * other.x, y * other.y };
+	}
+	constexpr vec2& operator*=(const vec2& other)
+	{
+		x *= other.x;
+		y *= other.y;
+		return *this;
+	}
+
+	constexpr vec2 operator/(const vec2& other)
+	{
+		return { x / other.x, y / other.y };
+	}
+	constexpr vec2& operator/=(const vec2& other)
+	{
+		x /= other.x;
+		y /= other.y;
+		return *this;
+	}
+
+	/*
+		Bracket operators
+	*/
+	T& operator[](uint32_t index)
+	{
+		assert(index >= 0 && index < 2);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		}
+	}
+
+	T const& operator[](uint32_t index) const
+	{
+		assert(index >= 0 && index < 2);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		}
+	}
+
+};
+
+/*
+	Binary arithmetic operators (vec2)
+*/
+template<typename T>
+constexpr vec2<T> operator+(const vec2<T>& v0, T scalar)
+{
+	return { v0.x + scalar, v0.y + scalar };
+}
+template<typename T>
+constexpr vec2<T>& operator+=(const vec2<T>& v0, T scalar)
+{
+	v0.x += scalar;
+	v0.y += scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec2<T> operator-(const vec2<T>& v0, T scalar)
+{
+	return { v0.x - scalar, v0.y - scalar };
+}
+template<typename T>
+constexpr vec2<T>& operator-=(const vec2<T>& v0, T scalar)
+{
+	v0.x -= scalar;
+	v0.y -= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec2<T> operator*(const vec2<T>& v0, T scalar)
+{
+	return { v0.x * scalar, v0.y * scalar };
+}
+template<typename T>
+constexpr vec2<T>& operator*=(const vec2<T>& v0, T scalar)
+{
+	v0.x *= scalar;
+	v0.y *= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec2<T> operator/(const vec2<T>& v0, T scalar)
+{
+	return { v0.x / scalar, v0.y / scalar };
+}
+template<typename T>
+constexpr vec2<T>& operator/=(const vec2<T>& v0, T scalar)
+{
+	v0.x /= scalar;
+	v0.y /= scalar;
+	return *this;
+}
+
+/*
+	vec3 implementation
+*/
+template<typename T>
+struct vec3
+{
+	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+
+	T x = 0, y = 0, z = 0;
+
+	/*
+		Constructors
+	*/
+	vec3() = default;
+	vec3(T scalar)
+	{
+		x = y = z = scalar;
+	}
+	vec3(T _x, T _y, T _z)
+	{
+		x = _x;
+		y = _y;
+		z = _z;
+	}
+
+	/*
+		Unary arithmetic operators
+	*/
+	constexpr vec3 operator+(const vec3& other)
+	{
+		return { x + other.x, y + other.y, z + other.z };
+	}
+	constexpr vec3& operator+=(const vec3& other)
+	{
+		x += other.x;
+		y += other.y;
+		z += other.z;
+		return *this;
+	}
+
+	constexpr vec3 operator-(const vec3& other)
+	{
+		return { x - other.x, y - other.y, z - other.z };
+	}
+	constexpr vec3& operator-=(const vec3& other)
+	{
+		x -= other.x;
+		y -= other.y;
+		z -= other.z;
+		return *this;
+	}
+
+	constexpr vec3 operator*(const vec3& other)
+	{
+		return { x * other.x, y * other.y, z * other.z };
+	}
+	constexpr vec3& operator*=(const vec3& other)
+	{
+		x *= other.x;
+		y *= other.y;
+		z *= other.z;
+		return *this;
+	}
+
+	constexpr vec3 operator/(const vec3& other)
+	{
+		return { x / other.x, y / other.y, z / other.z };
+	}
+	constexpr vec3& operator/=(const vec3& other)
+	{
+		x /= other.x;
+		y /= other.y;
+		z /= other.z;
+		return *this;
+	}
+
+	/*
+		Bracket operators
+	*/
+	T& operator[](uint32_t index)
+	{
+		assert(index >= 0 && index < 3);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		case 2:
+			return z;
+		}
+	}
+
+	T const& operator[](uint32_t index) const
+	{
+		assert(index >= 0 && index < 3);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		case 2:
+			return z;
+		}
+	}
+
+};
+
+/*
+	Binary arithmetic operators (vec3)
+*/
+template<typename T>
+constexpr vec3<T> operator+(const vec3<T>& v0, T scalar)
+{
+	return { v0.x + scalar, v0.y + scalar, v0.z + scalar };
+}
+template<typename T>
+constexpr vec3<T>& operator+=(const vec3<T>& v0, T scalar)
+{
+	v0.x += scalar;
+	v0.y += scalar;
+	v0.z += scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec3<T> operator-(const vec3<T>& v0, T scalar)
+{
+	return { v0.x - scalar, v0.y - scalar, v0.z - scalar };
+}
+template<typename T>
+constexpr vec3<T>& operator-=(const vec3<T>& v0, T scalar)
+{
+	v0.x -= scalar;
+	v0.y -= scalar;
+	v0.z -= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec3<T> operator*(const vec3<T>& v0, T scalar)
+{
+	return { v0.x * scalar, v0.y * scalar, v0.z * scalar };
+}
+template<typename T>
+constexpr vec3<T>& operator*=(const vec3<T>& v0, T scalar)
+{
+	v0.x *= scalar;
+	v0.y *= scalar;
+	v0.z *= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec3<T> operator/(const vec3<T>& v0, T scalar)
+{
+	return { v0.x / scalar, v0.y / scalar, v0.z / scalar };
+}
+template<typename T>
+constexpr vec3<T>& operator/=(const vec3<T>& v0, T scalar)
+{
+	v0.x /= scalar;
+	v0.y /= scalar;
+	v0.z /= scalar;
+	return *this;
+}
+
+/*
+	vec4 implementation
+*/
+template<typename T>
+struct vec4
+{
+	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+
+	T x = 0, y = 0, z = 0, w = 0;
+
+	/*
+		Constructors
+	*/
+	vec4() = default;
+	vec4(T scalar)
+	{
+		x = y = z = w = scalar;
+	}
+	vec4(T _x, T _y, T _z, T _w)
+	{
+		x = _x;
+		y = _y;
+		z = _z;
+		w = _w;
+	}
+
+	/*
+		Arithmetic operators
+	*/
+	constexpr vec4 operator+(const vec4& other)
+	{
+		return { x + other.x, y + other.y, z + other.z, w + other.w };
+	}
+	constexpr vec4& operator+=(const vec4& other)
+	{
+		x += other.x;
+		y += other.y;
+		z += other.z;
+		w += other.w;
+		return *this;
+	}
+
+	constexpr vec4 operator-(const vec4& other)
+	{
+		return { x - other.x, y - other.y, z - other.z, w - other.w };
+	}
+	constexpr vec4& operator-=(const vec4& other)
+	{
+		x -= other.x;
+		y -= other.y;
+		z -= other.z;
+		w -= other.w;
+		return *this;
+	}
+
+	constexpr vec4 operator*(const vec4& other)
+	{
+		return { x * other.x, y * other.y, z * other.z, w * other.w };
+	}
+	constexpr vec4& operator*=(const vec4& other)
+	{
+		x *= other.x;
+		y *= other.y;
+		z *= other.z;
+		w *= other.w;
+		return *this;
+	}
+
+	constexpr vec4 operator/(const vec4& other)
+	{
+		return { x / other.x, y / other.y, z / other.z, w / other.w };
+	}
+	constexpr vec4& operator/=(const vec4& other)
+	{
+		x /= other.x;
+		y /= other.y;
+		z /= other.z;
+		w /= other.w;
+		return *this;
+	}
+
+	/*
+		Bracket operators
+	*/
+	T& operator[](uint32_t index)
+	{
+		assert(index >= 0 && index < 4);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		case 2:
+			return z;
+		case 3:
+			return w;
+		}
+	}
+
+	T const& operator[](uint32_t index) const
+	{
+		assert(index >= 0 && index < 4);
+		switch (index)
+		{
+		default:
+		case 0:
+			return x;
+		case 1:
+			return y;
+		case 2:
+			return z;
+		case 3:
+			return w;
+		}
+	}
+
+};
+
+/*
+	Binary arithmetic operators (vec4)
+*/
+template<typename T>
+constexpr vec4<T> operator+(const vec4<T>& v0, T scalar)
+{
+	return { v0.x + scalar, v0.y + scalar, v0.z + scalar, v0.w + scalar };
+}
+template<typename T>
+constexpr vec4<T>& operator+=(const vec4<T>& v0, T scalar)
+{
+	v0.x += scalar;
+	v0.y += scalar;
+	v0.z += scalar;
+	v0.w += scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec4<T> operator-(const vec4<T>& v0, T scalar)
+{
+	return { v0.x - scalar, v0.y - scalar, v0.z - scalar, v0.w - scalar };
+}
+template<typename T>
+constexpr vec4<T>& operator-=(const vec4<T>& v0, T scalar)
+{
+	v0.x -= scalar;
+	v0.y -= scalar;
+	v0.z -= scalar;
+	v0.w -= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec4<T> operator*(const vec4<T>& v0, T scalar)
+{
+	return { v0.x * scalar, v0.y * scalar, v0.z * scalar, v0.w * scalar };
+}
+template<typename T>
+constexpr vec4<T>& operator*=(const vec4<T>& v0, T scalar)
+{
+	v0.x *= scalar;
+	v0.y *= scalar;
+	v0.z *= scalar;
+	v0.w *= scalar;
+	return *this;
+}
+
+template<typename T>
+constexpr vec4<T> operator/(const vec4<T>& v0, T scalar)
+{
+	return { v0.x / scalar, v0.y / scalar, v0.z / scalar, v0.w / scalar };
+}
+template<typename T>
+constexpr vec4<T>& operator/=(const vec4<T>& v0, T scalar)
+{
+	v0.x /= scalar;
+	v0.y /= scalar;
+	v0.z /= scalar;
+	v0.w /= scalar;
+	return *this;
+}
+
+/*
+	mat3 implementation
+*/
+template<typename T>
+struct mat3
+{
+	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+
+	vec3<T> value[3];
+
+	/*
+		Constructors
+	*/
+	mat3() = default;
+	mat3(T scalar)
+	{
+		value[0] = scalar;
+		value[1] = scalar;
+		value[2] = scalar;
+	}
+	mat3(const vec3<T>& v0, const vec3<T>& v1, const vec3<T>& v2)
+	{
+		value[0] = v0;
+		value[1] = v1;
+		value[2] = v2;
+	}
+
+	/*
+		Arithmetic operators
+	*/
+	constexpr mat3 operator+(const mat3<T>& other)
+	{
+		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2] };
+	}
+	constexpr mat3& operator+=(const mat3<T>& other)
+	{
+		value[0] += other.value[0];
+		value[1] += other.value[1];
+		value[2] += other.value[2];
+		return *this;
+	}
+
+	constexpr mat3 operator-(const mat3<T>& other)
+	{
+		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2] };
+	}
+	constexpr mat3& operator-=(const mat3<T>& other)
+	{
+		value[0] -= other.value[0];
+		value[1] -= other.value[1];
+		value[2] -= other.value[2];
+		return *this;
+	}
+
+	constexpr mat3 operator*(const mat3<T>& other)
+	{
+		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2] };
+	}
+	constexpr mat3& operator*=(const mat3<T>& other)
+	{
+		value[0] *= other.value[0];
+		value[1] *= other.value[1];
+		value[2] *= other.value[2];
+		return *this;
+	}
+
+	constexpr mat3 operator/(const mat3<T>& other)
+	{
+		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2] };
+	}
+	constexpr mat3& operator/=(const mat3<T>& other)
+	{
+		value[0] /= other.value[0];
+		value[1] /= other.value[1];
+		value[2] /= other.value[2];
+		return *this;
+	}
+
+	/*
+		Bracket operators
+	*/
+	vec3<T>& operator[](uint32_t index)
+	{
+		assert(index >= 0 && index < 3);
+		return value[index];
+	}
+
+	const vec3<T>& operator[](uint32_t index) const
+	{
+		assert(index >= 0 && index < 3);
+		return value[index];
+	}
+
+};
+
+/*
+	mat4 implementation
+*/
+template<typename T>
+struct mat4
+{
+	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+
+	vec4<T> value[4];
+
+	/*
+		Constructors
+	*/
+	mat4() = default;
+	mat4(T scalar)
+	{
+		value[0] = scalar;
+		value[1] = scalar;
+		value[2] = scalar;
+		value[3] = scalar;
+	}
+	mat4(const vec4<T>& v0, const vec4<T>& v1, const vec4<T>& v2, const vec4<T>& v3)
+	{
+		value[0] = v0;
+		value[1] = v1;
+		value[2] = v2;
+		value[3] = v3;
+	}
+
+	/*
+		Arithmetic operators
+	*/
+	constexpr mat4 operator+(const mat4<T>& other)
+	{
+		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2], value[3] + other.value[3] };
+	}
+	constexpr mat4& operator+=(const mat4<T>& other)
+	{
+		value[0] += other.value[0];
+		value[1] += other.value[1];
+		value[2] += other.value[2];
+		value[3] += other.value[3];
+		return *this;
+	}
+
+	constexpr mat4 operator-(const mat4<T>& other)
+	{
+		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2], value[3] - other.value[3] };
+	}
+	constexpr mat4& operator-=(const mat4<T>& other)
+	{
+		value[0] -= other.value[0];
+		value[1] -= other.value[1];
+		value[2] -= other.value[2];
+		value[3] -= other.value[3];
+		return *this;
+	}
+
+	constexpr mat4 operator*(const mat4<T>& other)
+	{
+		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2], value[3] * other.value[3] };
+	}
+	constexpr mat4& operator*=(const mat4<T>& other)
+	{
+		value[0] *= other.value[0];
+		value[1] *= other.value[1];
+		value[2] *= other.value[2];
+		value[3] *= other.value[3];
+		return *this;
+	}
+
+	constexpr mat4 operator/(const mat4<T>& other)
+	{
+		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2], value[3] / other.value[3] };
+	}
+	constexpr mat4& operator/=(const mat4<T>& other)
+	{
+		value[0] /= other.value[0];
+		value[1] /= other.value[1];
+		value[2] /= other.value[2];
+		value[3] /= other.value[3];
+		return *this;
+	}
+
+	/*
+		Bracket operators
+	*/
+	vec4<T>& operator[](uint32_t index)
+	{
+		assert(index >= 0 && index < 4);
+		return value[index];
+	}
+
+	const vec4<T>& operator[](uint32_t index) const
+	{
+		assert(index >= 0 && index < 4);
+		return value[index];
+	}
+
+};
+
+template<typename T>
+inline constexpr T dot(const vec2<T>& v0, const vec2<T>& v1)
+{
+	return v0.x * v1.x + v0.y * v1.y;
+}
+
+template<typename T>
+inline constexpr T dot(const vec3<T>& v0, const vec3<T>& v1)
+{
+	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z;
+}
+
+template<typename T>
+inline constexpr T dot(const vec4<T>& v0, const vec4<T>& v1)
+{
+	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z + v0.w * v1.w;
+}
+
+template<typename T>
+inline constexpr vec3<T> cross(const vec3<T>& v0, const vec3<T>& v1)
+{
+	return {
+		v0.y * v1.z - v0.z * v1.y,
+		v0.z * v1.x - v0.x * v1.z,
+		v0.x * v1.y - v0.y * v1.x
+	};
+}
+
+template<typename T>
+inline constexpr T length(const vec2<T>& v0)
+{
+	return std::sqrt(dot(v0, v0));
+}
+
+template<typename T>
+inline constexpr T length(const vec3<T>& v0)
+{
+	return std::sqrt(dot(v0, v0));
+}
+
+template<typename T>
+inline constexpr T length(const vec4<T>& v0)
+{
+	return std::sqrt(dot(v0, v0));
+}
+
+template<typename T>
+inline constexpr vec2<T> normalize(const vec2<T>& v0)
+{
+	return v0 * (1 / length(v0));
+}
+
+template<typename T>
+inline constexpr vec3<T> normalize(const vec3<T>& v0)
+{
+	return v0 * (1 / length(v0));
+}
+
+template<typename T>
+inline constexpr vec4<T> normalize(const vec4<T>& v0)
+{
+	return v0 * (1 / length(v0));
+}
+
+}

--- a/blib_math.h
+++ b/blib_math.h
@@ -3,7 +3,7 @@
 
 /*
 
-	Todo: Constructors / arithmetic operators / bracket operators
+	Todo: Quat, translate, rotate, scale, using typename aliases, eliminate bracket operator code duplication
 
 	Vec2: Constructors / arithmetic operators / bracket operators
 	Vec3: Constructors / arithmetic operators / bracket operators
@@ -22,21 +22,21 @@ namespace blib
 	vec2 implementation
 */
 template<typename T>
-struct vec2
+struct default_vec2
 {
-	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
 	T x = 0, y = 0;
 
 	/*
 		Constructors
 	*/
-	vec2() = default;
-	vec2(T scalar)
+	default_vec2() = default;
+	default_vec2(T scalar)
 	{
 		x = y = scalar;
 	}
-	vec2(T _x, T _y)
+	default_vec2(T _x, T _y)
 	{
 		x = _x;
 		y = _y;
@@ -45,44 +45,44 @@ struct vec2
 	/*
 		Arithmetic operators
 	*/
-	constexpr vec2 operator+(const vec2& other)
+	constexpr default_vec2 operator+(const default_vec2& other)
 	{
 		return { x + other.x, y + other.y };
 	}
-	constexpr vec2& operator+=(const vec2& other)
+	constexpr default_vec2& operator+=(const default_vec2& other)
 	{
 		x += other.x;
 		y += other.y;
 		return *this;
 	}
 
-	constexpr vec2 operator-(const vec2& other)
+	constexpr default_vec2 operator-(const default_vec2& other)
 	{
 		return { x - other.x, y - other.y };
 	}
-	constexpr vec2& operator-=(const vec2& other)
+	constexpr default_vec2& operator-=(const default_vec2& other)
 	{
 		x -= other.x;
 		y -= other.y;
 		return *this;
 	}
 
-	constexpr vec2 operator*(const vec2& other)
+	constexpr default_vec2 operator*(const default_vec2& other)
 	{
 		return { x * other.x, y * other.y };
 	}
-	constexpr vec2& operator*=(const vec2& other)
+	constexpr default_vec2& operator*=(const default_vec2& other)
 	{
 		x *= other.x;
 		y *= other.y;
 		return *this;
 	}
 
-	constexpr vec2 operator/(const vec2& other)
+	constexpr default_vec2 operator/(const default_vec2& other)
 	{
 		return { x / other.x, y / other.y };
 	}
-	constexpr vec2& operator/=(const vec2& other)
+	constexpr default_vec2& operator/=(const default_vec2& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -121,15 +121,15 @@ struct vec2
 };
 
 /*
-	Binary arithmetic operators (vec2)
+	Binary arithmetic operators (default_vec2)
 */
 template<typename T>
-constexpr vec2<T> operator+(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T> operator+(const default_vec2<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar };
 }
 template<typename T>
-constexpr vec2<T>& operator+=(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T>& operator+=(const default_vec2<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -137,12 +137,12 @@ constexpr vec2<T>& operator+=(const vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec2<T> operator-(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T> operator-(const default_vec2<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar };
 }
 template<typename T>
-constexpr vec2<T>& operator-=(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T>& operator-=(const default_vec2<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -150,12 +150,12 @@ constexpr vec2<T>& operator-=(const vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec2<T> operator*(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T> operator*(const default_vec2<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar };
 }
 template<typename T>
-constexpr vec2<T>& operator*=(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T>& operator*=(const default_vec2<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -163,12 +163,12 @@ constexpr vec2<T>& operator*=(const vec2<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec2<T> operator/(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T> operator/(const default_vec2<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar };
 }
 template<typename T>
-constexpr vec2<T>& operator/=(const vec2<T>& v0, T scalar)
+constexpr default_vec2<T>& operator/=(const default_vec2<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -179,21 +179,21 @@ constexpr vec2<T>& operator/=(const vec2<T>& v0, T scalar)
 	vec3 implementation
 */
 template<typename T>
-struct vec3
+struct default_vec3
 {
-	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
 	T x = 0, y = 0, z = 0;
 
 	/*
 		Constructors
 	*/
-	vec3() = default;
-	vec3(T scalar)
+	default_vec3() = default;
+	default_vec3(T scalar)
 	{
 		x = y = z = scalar;
 	}
-	vec3(T _x, T _y, T _z)
+	default_vec3(T _x, T _y, T _z)
 	{
 		x = _x;
 		y = _y;
@@ -203,11 +203,11 @@ struct vec3
 	/*
 		Unary arithmetic operators
 	*/
-	constexpr vec3 operator+(const vec3& other)
+	constexpr default_vec3 operator+(const default_vec3& other)
 	{
 		return { x + other.x, y + other.y, z + other.z };
 	}
-	constexpr vec3& operator+=(const vec3& other)
+	constexpr default_vec3& operator+=(const default_vec3& other)
 	{
 		x += other.x;
 		y += other.y;
@@ -215,11 +215,11 @@ struct vec3
 		return *this;
 	}
 
-	constexpr vec3 operator-(const vec3& other)
+	constexpr default_vec3 operator-(const default_vec3& other)
 	{
 		return { x - other.x, y - other.y, z - other.z };
 	}
-	constexpr vec3& operator-=(const vec3& other)
+	constexpr default_vec3& operator-=(const default_vec3& other)
 	{
 		x -= other.x;
 		y -= other.y;
@@ -227,11 +227,11 @@ struct vec3
 		return *this;
 	}
 
-	constexpr vec3 operator*(const vec3& other)
+	constexpr default_vec3 operator*(const default_vec3& other)
 	{
 		return { x * other.x, y * other.y, z * other.z };
 	}
-	constexpr vec3& operator*=(const vec3& other)
+	constexpr default_vec3& operator*=(const default_vec3& other)
 	{
 		x *= other.x;
 		y *= other.y;
@@ -239,11 +239,11 @@ struct vec3
 		return *this;
 	}
 
-	constexpr vec3 operator/(const vec3& other)
+	constexpr default_vec3 operator/(const default_vec3& other)
 	{
 		return { x / other.x, y / other.y, z / other.z };
 	}
-	constexpr vec3& operator/=(const vec3& other)
+	constexpr default_vec3& operator/=(const default_vec3& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -287,15 +287,15 @@ struct vec3
 };
 
 /*
-	Binary arithmetic operators (vec3)
+	Binary arithmetic operators (default_vec3)
 */
 template<typename T>
-constexpr vec3<T> operator+(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T> operator+(const default_vec3<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar, v0.z + scalar };
 }
 template<typename T>
-constexpr vec3<T>& operator+=(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T>& operator+=(const default_vec3<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -304,12 +304,12 @@ constexpr vec3<T>& operator+=(const vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec3<T> operator-(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T> operator-(const default_vec3<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar, v0.z - scalar };
 }
 template<typename T>
-constexpr vec3<T>& operator-=(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T>& operator-=(const default_vec3<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -318,12 +318,12 @@ constexpr vec3<T>& operator-=(const vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec3<T> operator*(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T> operator*(const default_vec3<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar, v0.z * scalar };
 }
 template<typename T>
-constexpr vec3<T>& operator*=(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T>& operator*=(const default_vec3<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -332,12 +332,12 @@ constexpr vec3<T>& operator*=(const vec3<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec3<T> operator/(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T> operator/(const default_vec3<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar, v0.z / scalar };
 }
 template<typename T>
-constexpr vec3<T>& operator/=(const vec3<T>& v0, T scalar)
+constexpr default_vec3<T>& operator/=(const default_vec3<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -349,21 +349,21 @@ constexpr vec3<T>& operator/=(const vec3<T>& v0, T scalar)
 	vec4 implementation
 */
 template<typename T>
-struct vec4
+struct default_vec4
 {
-	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
 	T x = 0, y = 0, z = 0, w = 0;
 
 	/*
 		Constructors
 	*/
-	vec4() = default;
-	vec4(T scalar)
+	default_vec4() = default;
+	default_vec4(T scalar)
 	{
 		x = y = z = w = scalar;
 	}
-	vec4(T _x, T _y, T _z, T _w)
+	default_vec4(T _x, T _y, T _z, T _w)
 	{
 		x = _x;
 		y = _y;
@@ -374,11 +374,11 @@ struct vec4
 	/*
 		Arithmetic operators
 	*/
-	constexpr vec4 operator+(const vec4& other)
+	constexpr default_vec4 operator+(const default_vec4& other)
 	{
 		return { x + other.x, y + other.y, z + other.z, w + other.w };
 	}
-	constexpr vec4& operator+=(const vec4& other)
+	constexpr default_vec4& operator+=(const default_vec4& other)
 	{
 		x += other.x;
 		y += other.y;
@@ -387,11 +387,11 @@ struct vec4
 		return *this;
 	}
 
-	constexpr vec4 operator-(const vec4& other)
+	constexpr default_vec4 operator-(const default_vec4& other)
 	{
 		return { x - other.x, y - other.y, z - other.z, w - other.w };
 	}
-	constexpr vec4& operator-=(const vec4& other)
+	constexpr default_vec4& operator-=(const default_vec4& other)
 	{
 		x -= other.x;
 		y -= other.y;
@@ -400,11 +400,11 @@ struct vec4
 		return *this;
 	}
 
-	constexpr vec4 operator*(const vec4& other)
+	constexpr default_vec4 operator*(const default_vec4& other)
 	{
 		return { x * other.x, y * other.y, z * other.z, w * other.w };
 	}
-	constexpr vec4& operator*=(const vec4& other)
+	constexpr default_vec4& operator*=(const default_vec4& other)
 	{
 		x *= other.x;
 		y *= other.y;
@@ -413,11 +413,11 @@ struct vec4
 		return *this;
 	}
 
-	constexpr vec4 operator/(const vec4& other)
+	constexpr default_vec4 operator/(const default_vec4& other)
 	{
 		return { x / other.x, y / other.y, z / other.z, w / other.w };
 	}
-	constexpr vec4& operator/=(const vec4& other)
+	constexpr default_vec4& operator/=(const default_vec4& other)
 	{
 		x /= other.x;
 		y /= other.y;
@@ -466,15 +466,15 @@ struct vec4
 };
 
 /*
-	Binary arithmetic operators (vec4)
+	Binary arithmetic operators (default_vec4)
 */
 template<typename T>
-constexpr vec4<T> operator+(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T> operator+(const default_vec4<T>& v0, T scalar)
 {
 	return { v0.x + scalar, v0.y + scalar, v0.z + scalar, v0.w + scalar };
 }
 template<typename T>
-constexpr vec4<T>& operator+=(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T>& operator+=(const default_vec4<T>& v0, T scalar)
 {
 	v0.x += scalar;
 	v0.y += scalar;
@@ -484,12 +484,12 @@ constexpr vec4<T>& operator+=(const vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec4<T> operator-(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T> operator-(const default_vec4<T>& v0, T scalar)
 {
 	return { v0.x - scalar, v0.y - scalar, v0.z - scalar, v0.w - scalar };
 }
 template<typename T>
-constexpr vec4<T>& operator-=(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T>& operator-=(const default_vec4<T>& v0, T scalar)
 {
 	v0.x -= scalar;
 	v0.y -= scalar;
@@ -499,12 +499,12 @@ constexpr vec4<T>& operator-=(const vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec4<T> operator*(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T> operator*(const default_vec4<T>& v0, T scalar)
 {
 	return { v0.x * scalar, v0.y * scalar, v0.z * scalar, v0.w * scalar };
 }
 template<typename T>
-constexpr vec4<T>& operator*=(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T>& operator*=(const default_vec4<T>& v0, T scalar)
 {
 	v0.x *= scalar;
 	v0.y *= scalar;
@@ -514,12 +514,12 @@ constexpr vec4<T>& operator*=(const vec4<T>& v0, T scalar)
 }
 
 template<typename T>
-constexpr vec4<T> operator/(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T> operator/(const default_vec4<T>& v0, T scalar)
 {
 	return { v0.x / scalar, v0.y / scalar, v0.z / scalar, v0.w / scalar };
 }
 template<typename T>
-constexpr vec4<T>& operator/=(const vec4<T>& v0, T scalar)
+constexpr default_vec4<T>& operator/=(const default_vec4<T>& v0, T scalar)
 {
 	v0.x /= scalar;
 	v0.y /= scalar;
@@ -532,23 +532,23 @@ constexpr vec4<T>& operator/=(const vec4<T>& v0, T scalar)
 	mat3 implementation
 */
 template<typename T>
-struct mat3
+struct default_mat3
 {
-	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
-	vec3<T> value[3];
+	default_vec3<T> value[3];
 
 	/*
 		Constructors
 	*/
-	mat3() = default;
-	mat3(T scalar)
+	default_mat3() = default;
+	default_mat3(T scalar)
 	{
 		value[0] = scalar;
 		value[1] = scalar;
 		value[2] = scalar;
 	}
-	mat3(const vec3<T>& v0, const vec3<T>& v1, const vec3<T>& v2)
+	default_mat3(const default_vec3<T>& v0, const default_vec3<T>& v1, const default_vec3<T>& v2)
 	{
 		value[0] = v0;
 		value[1] = v1;
@@ -558,11 +558,11 @@ struct mat3
 	/*
 		Arithmetic operators
 	*/
-	constexpr mat3 operator+(const mat3<T>& other)
+	constexpr default_mat3 operator+(const default_mat3<T>& other)
 	{
 		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2] };
 	}
-	constexpr mat3& operator+=(const mat3<T>& other)
+	constexpr default_mat3& operator+=(const default_mat3<T>& other)
 	{
 		value[0] += other.value[0];
 		value[1] += other.value[1];
@@ -570,11 +570,11 @@ struct mat3
 		return *this;
 	}
 
-	constexpr mat3 operator-(const mat3<T>& other)
+	constexpr default_mat3 operator-(const default_mat3<T>& other)
 	{
 		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2] };
 	}
-	constexpr mat3& operator-=(const mat3<T>& other)
+	constexpr default_mat3& operator-=(const default_mat3<T>& other)
 	{
 		value[0] -= other.value[0];
 		value[1] -= other.value[1];
@@ -582,11 +582,11 @@ struct mat3
 		return *this;
 	}
 
-	constexpr mat3 operator*(const mat3<T>& other)
+	constexpr default_mat3 operator*(const default_mat3<T>& other)
 	{
 		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2] };
 	}
-	constexpr mat3& operator*=(const mat3<T>& other)
+	constexpr default_mat3& operator*=(const default_mat3<T>& other)
 	{
 		value[0] *= other.value[0];
 		value[1] *= other.value[1];
@@ -594,11 +594,11 @@ struct mat3
 		return *this;
 	}
 
-	constexpr mat3 operator/(const mat3<T>& other)
+	constexpr default_mat3 operator/(const default_mat3<T>& other)
 	{
 		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2] };
 	}
-	constexpr mat3& operator/=(const mat3<T>& other)
+	constexpr default_mat3& operator/=(const default_mat3<T>& other)
 	{
 		value[0] /= other.value[0];
 		value[1] /= other.value[1];
@@ -609,13 +609,13 @@ struct mat3
 	/*
 		Bracket operators
 	*/
-	vec3<T>& operator[](uint32_t index)
+	default_vec3<T>& operator[](uint32_t index)
 	{
 		assert(index >= 0 && index < 3);
 		return value[index];
 	}
 
-	const vec3<T>& operator[](uint32_t index) const
+	const default_vec3<T>& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 3);
 		return value[index];
@@ -627,24 +627,24 @@ struct mat3
 	mat4 implementation
 */
 template<typename T>
-struct mat4
+struct default_mat4
 {
-	static_assert(std::is_scalar_v<T>, "Templated type T must be a scalar type");
+	static_assert(std::is_arithmetic_v<T>, "Templated type T must be an arithmetic type");
 
-	vec4<T> value[4];
+	default_vec4<T> value[4];
 
 	/*
 		Constructors
 	*/
-	mat4() = default;
-	mat4(T scalar)
+	default_mat4() = default;
+	default_mat4(T scalar)
 	{
 		value[0] = scalar;
 		value[1] = scalar;
 		value[2] = scalar;
 		value[3] = scalar;
 	}
-	mat4(const vec4<T>& v0, const vec4<T>& v1, const vec4<T>& v2, const vec4<T>& v3)
+	default_mat4(const default_vec4<T>& v0, const default_vec4<T>& v1, const default_vec4<T>& v2, const default_vec4<T>& v3)
 	{
 		value[0] = v0;
 		value[1] = v1;
@@ -655,11 +655,11 @@ struct mat4
 	/*
 		Arithmetic operators
 	*/
-	constexpr mat4 operator+(const mat4<T>& other)
+	constexpr default_mat4 operator+(const default_mat4<T>& other)
 	{
 		return { value[0] + other.value[0], value[1] + other.value[1], value[2] + other.value[2], value[3] + other.value[3] };
 	}
-	constexpr mat4& operator+=(const mat4<T>& other)
+	constexpr default_mat4& operator+=(const default_mat4<T>& other)
 	{
 		value[0] += other.value[0];
 		value[1] += other.value[1];
@@ -668,11 +668,11 @@ struct mat4
 		return *this;
 	}
 
-	constexpr mat4 operator-(const mat4<T>& other)
+	constexpr default_mat4 operator-(const default_mat4<T>& other)
 	{
 		return { value[0] - other.value[0], value[1] - other.value[1], value[2] - other.value[2], value[3] - other.value[3] };
 	}
-	constexpr mat4& operator-=(const mat4<T>& other)
+	constexpr default_mat4& operator-=(const default_mat4<T>& other)
 	{
 		value[0] -= other.value[0];
 		value[1] -= other.value[1];
@@ -681,11 +681,11 @@ struct mat4
 		return *this;
 	}
 
-	constexpr mat4 operator*(const mat4<T>& other)
+	constexpr default_mat4 operator*(const default_mat4<T>& other)
 	{
 		return { value[0] * other.value[0], value[1] * other.value[1], value[2] * other.value[2], value[3] * other.value[3] };
 	}
-	constexpr mat4& operator*=(const mat4<T>& other)
+	constexpr default_mat4& operator*=(const default_mat4<T>& other)
 	{
 		value[0] *= other.value[0];
 		value[1] *= other.value[1];
@@ -694,11 +694,11 @@ struct mat4
 		return *this;
 	}
 
-	constexpr mat4 operator/(const mat4<T>& other)
+	constexpr default_mat4 operator/(const default_mat4<T>& other)
 	{
 		return { value[0] / other.value[0], value[1] / other.value[1], value[2] / other.value[2], value[3] / other.value[3] };
 	}
-	constexpr mat4& operator/=(const mat4<T>& other)
+	constexpr default_mat4& operator/=(const default_mat4<T>& other)
 	{
 		value[0] /= other.value[0];
 		value[1] /= other.value[1];
@@ -710,13 +710,13 @@ struct mat4
 	/*
 		Bracket operators
 	*/
-	vec4<T>& operator[](uint32_t index)
+	default_vec4<T>& operator[](uint32_t index)
 	{
 		assert(index >= 0 && index < 4);
 		return value[index];
 	}
 
-	const vec4<T>& operator[](uint32_t index) const
+	const default_vec4<T>& operator[](uint32_t index) const
 	{
 		assert(index >= 0 && index < 4);
 		return value[index];
@@ -725,25 +725,25 @@ struct mat4
 };
 
 template<typename T>
-inline constexpr T dot(const vec2<T>& v0, const vec2<T>& v1)
+inline constexpr T dot(const default_vec2<T>& v0, const default_vec2<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y;
 }
 
 template<typename T>
-inline constexpr T dot(const vec3<T>& v0, const vec3<T>& v1)
+inline constexpr T dot(const default_vec3<T>& v0, const default_vec3<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z;
 }
 
 template<typename T>
-inline constexpr T dot(const vec4<T>& v0, const vec4<T>& v1)
+inline constexpr T dot(const default_vec4<T>& v0, const default_vec4<T>& v1)
 {
 	return v0.x * v1.x + v0.y * v1.y + v0.z * v1.z + v0.w * v1.w;
 }
 
 template<typename T>
-inline constexpr vec3<T> cross(const vec3<T>& v0, const vec3<T>& v1)
+inline constexpr default_vec3<T> cross(const default_vec3<T>& v0, const default_vec3<T>& v1)
 {
 	return {
 		v0.y * v1.z - v0.z * v1.y,
@@ -753,39 +753,45 @@ inline constexpr vec3<T> cross(const vec3<T>& v0, const vec3<T>& v1)
 }
 
 template<typename T>
-inline constexpr T length(const vec2<T>& v0)
+inline constexpr T length(const default_vec2<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr T length(const vec3<T>& v0)
+inline constexpr T length(const default_vec3<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr T length(const vec4<T>& v0)
+inline constexpr T length(const default_vec4<T>& v0)
 {
 	return std::sqrt(dot(v0, v0));
 }
 
 template<typename T>
-inline constexpr vec2<T> normalize(const vec2<T>& v0)
+inline constexpr default_vec2<T> normalize(const default_vec2<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
 
 template<typename T>
-inline constexpr vec3<T> normalize(const vec3<T>& v0)
+inline constexpr default_vec3<T> normalize(const default_vec3<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
 
 template<typename T>
-inline constexpr vec4<T> normalize(const vec4<T>& v0)
+inline constexpr default_vec4<T> normalize(const default_vec4<T>& v0)
 {
 	return v0 * (1 / length(v0));
 }
+
+using vec2 = default_vec2<float>;
+using vec3 = default_vec3<float>;
+using vec4 = default_vec4<float>;
+using mat3 = default_mat3<float>;
+using mat4 = default_mat4<float>;
 
 }


### PR DESCRIPTION
Added math library, with the following functionality:
- Data types for vec2, vec3, vec4, mat3, mat4
- Arithmetic operators for all of these types
- Bracket operators for all of these types
- Dot, cross, length, and normalize functions
- Perspective projections (LH, RH, 0..1, -1..1)
- Transposing matrices
- Radians and degrees conversion functions

Missing:
- Matrix helpers for orthographic projections and view matrices
- Matrix operations (translate, rotate, scale)
- Quaternion data type
- Unit testing

Issue: #2 